### PR TITLE
Modernize infra: local-dev ergonomics, dep bumps, Node 24 LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,21 @@ Most likely an external tool as we want to support WordPress, WordPress with Led
 
 _(not yet built, nor begun)_
 
+## `jacket`
+
+**The BRIET homepage**
+
+A small Next.js site serving [briet.app](https://briet.app/), with content from the BRIET Catalog (Sanity).
+
+### `jacket` Development
+
+`npm install` from the repo root, then in `apps/jacket` either `npm run dev:local` (plain `next dev`, needs the `NEXT_PUBLIC_SANITY_*` vars in `.env.local`) or `npm run dev` for the Vercel flow (project `bh-briet-jacket`).
+
 ## `tagger`
 
 **BRIET Books ⮕ BRIET Catalog**
 
-CMS to to manage the BRIET Catalog: metadata, prices, and asset files for digital books and other digital items. Built on Sanity, user access managed by BRIET staff.
+CMS to manage the BRIET Catalog: metadata, prices, and asset files for digital books and other digital items. Built on Sanity, user access managed by BRIET staff.
 
 In production at **tagger.briet.app**
 
@@ -49,7 +59,7 @@ You need to be pretty strict about node@20 (latest stable version is fine)— ve
 
 `vc dev` to link with Vercel first time, pull env vars, & run
 
-or `npm run dev` if you just want to tinker locally, but you will need probably some env vars from another developer (try Jacob)
+**Or, without Vercel:** `npm run dev:local` runs `sanity dev` directly — after `sanity login`, no env vars needed (`.env.development` carries the non-secret project ID).
 
 ## `server`
 
@@ -93,7 +103,13 @@ You'll need
 
 `vc dev`
 
-or `npx next dev` if you just want to tinker locally, but you will need probably some env vars from another developer (try Jacob)
+**Or, without Vercel:** copy `.env.example` to `.env.local` and fill in the Sanity vars (ask another developer), then `npm run dev:local`. That's enough to browse the catalog locally — the Stripe key only matters if you're working on the checkout flow.
+
+## `reader`
+
+**In-browser ebook reading**
+
+A static build of the Internet Archive [BookReader](https://github.com/internetarchive/bookreader) plus a Vercel Edge function (`api/getPage`) that renders page images. `npm run dev` in `apps/reader` serves the static files with `http-server`; the edge function itself only runs under `vercel dev`.
 
 ## `lender` (Lenny)
 
@@ -111,7 +127,7 @@ Our fork is https://github.com/brickhousecoop/lenny
 
 ## How to spell “ebook”
 
-It is spelled `ebook` or `ebooks`. Not `e-book`, `eBook`, or `e-Book`. Ebook should be capititalized only when you would normally capitalize a word.
+It is spelled `ebook` or `ebooks`. Not `e-book`, `eBook`, or `e-Book`. Ebook should be capitalized only when you would normally capitalize a word.
 
 ## On the etymological difference between _lending_ and _loaning_
 

--- a/apps/jacket/README.md
+++ b/apps/jacket/README.md
@@ -1,36 +1,11 @@
-This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+# `jacket` — BRIET homepage
 
-## Getting Started
+The main [briet.app](https://briet.app/) site. Next.js 14 (app router), content from the BRIET Catalog (Sanity).
 
-First, run the development server:
+## Development
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-```
+1. `npm install` from the repo root
+2. Put `NEXT_PUBLIC_SANITY_PROJECTID` and `NEXT_PUBLIC_SANITY_DATASET` in `.env.local`
+3. `npm run dev:local` (plain `next dev`)
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
-
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
-
-[http://localhost:3000/api/hello](http://localhost:3000/api/hello) is an endpoint that uses [Route Handlers](https://beta.nextjs.org/docs/routing/route-handlers). This endpoint can be edited in `app/api/hello/route.ts`.
-
-This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+`npm run dev` instead runs the full Vercel flow (project `bh-briet-jacket`), which requires membership in the Brick House Vercel team.

--- a/apps/jacket/package.json
+++ b/apps/jacket/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "dev": "npm run --prefix ../../ dev-jacket",
+    "dev:local": "next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/apps/market/.env.example
+++ b/apps/market/.env.example
@@ -1,0 +1,14 @@
+# Copy to .env.local and fill in values (ask another developer, or pull from
+# Vercel with `vc env pull`). Only the Sanity vars are required to browse the
+# catalog locally.
+
+# Sanity CMS (required)
+NEXT_PUBLIC_SANITY_PROJECTID=
+NEXT_PUBLIC_SANITY_DATASET=production
+SANITY_TOKEN=
+
+# Stripe checkout (only needed for the purchase flow)
+STRIPE_SECRET_KEY=
+
+# Fathom analytics (optional, no-op if unset)
+NEXT_PUBLIC_FATHOM_SITEID=

--- a/apps/market/README.md
+++ b/apps/market/README.md
@@ -1,34 +1,13 @@
-This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+# `market` — BRIET Bookmarket
 
-## Getting Started
+The public-facing marketplace at [market.briet.app](https://market.briet.app/), where libraries purchase ebooks. Next.js 14, catalog content from Sanity, checkout via Stripe, auth via Clerk.
 
-First, run the development server:
+## Development
 
-```bash
-npm run dev
-# or
-yarn dev
-```
+See the [root README](../../README.md) for full setup. Quick version:
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+1. `npm install` from the repo root
+2. Copy `.env.example` to `.env.local` and fill in the Sanity vars (ask another developer, or `vc env pull` if you have Vercel access)
+3. `npm run dev:local` (plain `next dev`)
 
-You can start editing the page by modifying `pages/index.js`. The page auto-updates as you edit the file.
-
-[API routes](https://nextjs.org/docs/api-routes/introduction) can be accessed on [http://localhost:3000/api/hello](http://localhost:3000/api/hello). This endpoint can be edited in `pages/api/hello.js`.
-
-The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead of React pages.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+`npm run dev` instead runs the full Vercel flow (`vercel link/pull/dev`), which requires membership in the Brick House Vercel team.

--- a/apps/market/package.json
+++ b/apps/market/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "build": "next build",
     "dev": "npm run --prefix ../../ dev-market",
+    "dev:local": "next dev",
     "lint": "next lint",
     "start": "next start"
   },

--- a/apps/tagger/.env.development
+++ b/apps/tagger/.env.development
@@ -1,0 +1,4 @@
+# Loaded by `sanity dev`. These are not secrets (the project ID is public);
+# your access is controlled by `npx sanity login`.
+SANITY_STUDIO_PROJECTID=3lm68n5v
+SANITY_STUDIO_DATASET=production

--- a/apps/tagger/package.json
+++ b/apps/tagger/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "build": "sanity build",
     "dev": "npm run --prefix ../../ dev-tagger",
+    "dev:local": "sanity dev",
     "start": "sanity start"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build:tagger": "dotenv -e .vercel/.env -c development -- turbo run build --filter=bh-briet-tagger",
     "build:server": "dotenv -e .vercel/.env -c development -- turbo run build --filter=bh-briet-server",
     "build:market": "dotenv -e .vercel/.env -c development -- turbo run build --filter=bh-briet-market",
-    "build:reader": "dotenv -e .vercel/.env -c development -- turbo run build --filter=bh-briet-market"
+    "build:reader": "dotenv -e .vercel/.env -c development -- turbo run build --filter=bh-briet-reader"
   },
   "devDependencies": {
     "eslint": "^8.56.0",


### PR DESCRIPTION
Follow-on to #105 — the Vercel-free local dev path and doc cleanup.

- Add `dev:local` scripts: `next dev` (market, jacket), `sanity dev` (tagger) — run apps without `vercel dev`/Vercel team access
- Add `apps/market/.env.example` (var names only) and `apps/tagger/.env.development` (non-secret Sanity project ID)
- Fix `build:reader` in root package.json — it was filtering `bh-briet-market` instead of `bh-briet-reader`
- Document `jacket` and `reader` apps in the root README (previously undocumented) + Vercel-free dev instructions; drop create-next-app boilerplate from market/jacket READMEs

Rebased onto `staging` so it applies cleanly on top of #105 (devEngines, .nvmrc, etc.).